### PR TITLE
ZIA-6036: Pause ads vast tracking events missing

### DIFF
--- a/Sources/VastClient/models/XML schema/VastTrackingEvent.swift
+++ b/Sources/VastClient/models/XML schema/VastTrackingEvent.swift
@@ -33,6 +33,8 @@ public enum TrackingEventType: String, Codable {
     case acceptInvitation
     case close
     case unknown
+    case overlayViewDuration
+    case otherAdInteraction
 }
 
 struct TrackingEventAttributes {


### PR DESCRIPTION
This PR adds to the VastClient project two missing vast tracking event types: overlayViewDuration and otherAdInteraction
